### PR TITLE
Continuation of sync-improvement PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,14 @@ DEB_HASH=$(shell git rev-parse HEAD)
 
 all: build-node-linux
 
+dev: build-node-linux-test
+
 lint:
 	./build/env.sh go fmt ./...
+
+build-node-linux-test:
+	./build/env.sh go get -v ./...
+	./build/env.sh go build -race -o build/bin/node ./src/node
 
 build-node-linux:
 	./build/env.sh go get -v ./...

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/anacrolix/dht/v2 v2.14.1-0.20211220010335-4062f7927abf
 	github.com/anacrolix/log v0.10.0
 	github.com/anacrolix/torrent v1.40.0
+	github.com/autom8ter/dagger v1.0.1 // indirect
 	github.com/br0xen/boltbrowser v0.0.0-20210531150353-7f10a81cece0 // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/golang-lru v0.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
+github.com/autom8ter/dagger v1.0.1 h1:z6SZwfH/dFxPniOukgeCir3a4ki93OPL1DrnuFTmtJA=
+github.com/autom8ter/dagger v1.0.1/go.mod h1:asg7HPk+oMpvi9lu9I+IHGlz8FKSxjf61PwKe+CfVeA=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=

--- a/src/blockchain/blockchain.go
+++ b/src/blockchain/blockchain.go
@@ -1,0 +1,81 @@
+package blockchain
+
+import (
+	"github.com/autom8ter/dagger"
+	"github.com/overline-mining/gool/src/common"
+	"github.com/overline-mining/gool/src/database"
+	//"github.com/overline-mining/gool/src/validation"
+	p2p_pb "github.com/overline-mining/gool/src/protos"
+	"go.uber.org/zap"
+)
+
+const (
+	BLOCK_TYPE      = "block"
+	CONNECTION_TYPE = "connects"
+)
+
+type OverlineBlockchain struct {
+	BlockGraph *dagger.Graph
+	DB         *database.OverlineDB
+}
+
+func (obc *OverlineBlockchain) AddBlock(block *p2p_pb.BcBlock) {
+	_, found := obc.BlockGraph.GetNode(
+		dagger.Path{
+			XID:   block.GetHash(),
+			XType: BLOCK_TYPE,
+		})
+	if found { // no need to process a block that is already in the graph
+		return
+	}
+	// create the node in the block graph
+	blkNode := obc.BlockGraph.SetNode(
+		dagger.Path{
+			XID:   block.GetHash(),
+			XType: BLOCK_TYPE,
+		},
+		map[string]interface{}{
+			"block": block,
+		})
+	// get the parent node if it exists
+	parentNode, found := obc.BlockGraph.GetNode(
+		dagger.Path{
+			XID:   block.GetPreviousHash(),
+			XType: BLOCK_TYPE,
+		})
+	if found {
+		zap.S().Infof(
+			"got found previous hash %v -> %v %v",
+			block.GetPreviousHash(),
+			parentNode.Attributes["block"].(*p2p_pb.BcBlock).GetHash(),
+			found,
+		)
+		_, err := obc.BlockGraph.SetEdge(blkNode.Path, parentNode.Path, dagger.Node{
+			Path: dagger.Path{
+				XType: CONNECTION_TYPE,
+			},
+			Attributes: map[string]interface{}{},
+		})
+		if err != nil {
+			zap.S().Panic(err)
+		}
+	} else {
+		zap.S().Infof(
+			"Could not find previous hash %v for new block %v @ %v",
+			common.BriefHash(block.GetPreviousHash()),
+			common.BriefHash(block.GetHash()),
+			block.GetHeight(),
+		)
+	}
+	obc.BlockGraph.DFS(CONNECTION_TYPE, blkNode.Path, func(node dagger.Node) bool {
+		zap.S().Debugf("(%v) DFS: %s", node.Attributes["block"].(*p2p_pb.BcBlock).GetHeight(), node.Attributes["block"].(*p2p_pb.BcBlock).GetHash())
+		return true
+	})
+	zap.S().Debugf("(%v) DFS-ROOT: %s", block.GetHeight(), block.GetHash())
+}
+
+func (obc *OverlineBlockchain) AddBlockRange(blocks *p2p_pb.BcBlocks) {
+	for _, block := range blocks.Blocks {
+		obc.AddBlock(block)
+	}
+}

--- a/src/blockchain/blockchain.go
+++ b/src/blockchain/blockchain.go
@@ -16,10 +16,31 @@ const (
 )
 
 type OverlineBlockchain struct {
-	Mu         sync.Mutex
-	Heads      map[string]bool
-	BlockGraph *dagger.Graph
-	DB         *database.OverlineDB
+	Mu                               sync.Mutex
+	followMu                         sync.Mutex
+	Heads                            map[string]bool
+	BlockGraph                       *dagger.Graph
+	DB                               *database.OverlineDB
+	isFollowingChain                 bool
+	IbdTransitionPeriodRelativeDepth float64
+}
+
+func (obc *OverlineBlockchain) SetFollowingChain() {
+	obc.followMu.Lock()
+	obc.isFollowingChain = true
+	obc.followMu.Unlock()
+}
+
+func (obc *OverlineBlockchain) UnsetFollowingChain() {
+	obc.followMu.Lock()
+	obc.isFollowingChain = false
+	obc.followMu.Unlock()
+}
+
+func (obc *OverlineBlockchain) IsFollowingChain() bool {
+	obc.followMu.Lock()
+	defer obc.followMu.Unlock()
+	return obc.isFollowingChain
 }
 
 func (obc *OverlineBlockchain) AddBlock(block *p2p_pb.BcBlock) {

--- a/src/database/db.go
+++ b/src/database/db.go
@@ -245,6 +245,13 @@ func (odb *OverlineDB) SerializedHeight() uint64 {
 	return odb.tipOfSerializedChain.GetHeight()
 }
 
+func (odb *OverlineDB) HighestSerializedBlock() p2p_pb.BcBlock {
+	odb.mu.Lock()
+	defer odb.mu.Unlock()
+	block := *odb.tipOfSerializedChain
+	return block
+}
+
 func (odb *OverlineDB) AddBlock(block *p2p_pb.BcBlock) error {
 	isValid, err := validation.IsValidBlock(block)
 	if !isValid {

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -335,6 +335,7 @@ func main() {
 	ovlChain := chain.OverlineBlockchain{
 		BlockGraph: dagger.NewGraph(),
 		DB:         &gooldb,
+		Heads:      make(map[string]bool),
 	}
 
 	id_bytes := make([]byte, 32)

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -56,6 +56,7 @@ var (
 	olWorkDir           = flag.String("ol-workdir", ".overline", "Specify the working directory for the node")
 	dbFileName          = flag.String("db-file-name", "overline.boltdb", "The file we're going to write the blockchain to within olWorkDir")
 	validateFullChain   = flag.Bool("full-validation", false, "Run a slow but complete validation of your local blockchain DB")
+	dropChainstate      = flag.Bool("drop-chainstate", false, "Delete the last saved chainstate from the database")
 )
 
 type ConcurrentPeerMap struct {
@@ -291,7 +292,7 @@ func main() {
 	startingHeight := uint64(0)
 	dbFilePath := filepath.Join(*olWorkDir, *dbFileName)
 	gooldb := db.OverlineDB{Config: db.DefaultOverlineDBConfig()}
-	err = gooldb.Open(dbFilePath)
+	err = gooldb.Open(dbFilePath, *dropChainstate)
 
 	if err != nil {
 		startingHeight = 1

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -546,7 +546,6 @@ func main() {
 							ibdWorkList.Mu.Unlock()
 							blocks = goodBlocks
 							ibdBar.Add(len(blocks.Blocks))
-							zap.S().Infof("Highest peer height %v / highest received block %v", highestNonZeroPeerHeight, highestReceivedBlock)
 							if highestNonZeroPeerHeight != 0 && highestNonZeroPeerHeight-10 < highestReceivedBlock {
 								gooldb.UnSetInitialBlockDownload()
 							}

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -532,7 +532,9 @@ func main() {
 					case messages.DATA:
 						blocks := p2p_pb.BcBlocks{}
 						err = proto.Unmarshal(oneMessage.Value, &blocks)
-						zap.S().Debugf("Got blocklist with starting value: %v %v", blocks.Blocks[0].GetHeight(), blocks.Blocks[0].GetHash())
+						if err == nil && len(blocks.Blocks) > 0 {
+							zap.S().Debugf("Got blocklist with starting value: %v %v", blocks.Blocks[0].GetHeight(), blocks.Blocks[0].GetHash())
+						}
 						if gooldb.IsInitialBlockDownload() {
 							goodBlocks := p2p_pb.BcBlocks{}
 							ibdWorkList.Mu.Lock()

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -511,7 +511,7 @@ func main() {
 				}
 			}
 			olHandlerMapMu.Unlock()
-			if !goolChain.IsFollowingChain() && lowestNonZeroPeerHeight*(1-goolChain.IbdTransitionPeriodRelativeDepth) < thresholdDbl {
+			if !goolChain.IsFollowingChain() && lowestNonZeroPeerHeight > 0.0 && lowestNonZeroPeerHeight*(1-goolChain.IbdTransitionPeriodRelativeDepth) < thresholdDbl {
 				goolChain.SetFollowingChain()
 			}
 			olMessageMu.Lock()

--- a/src/olhash/difficulty.go
+++ b/src/olhash/difficulty.go
@@ -1,0 +1,221 @@
+package olhash
+
+import (
+	p2p_pb "github.com/overline-mining/gool/src/protos"
+	"math/big"
+)
+
+// These functions are filled with strange apocrypha from
+// the js implementation of the node. Lots of patches.
+
+const (
+	MIN_DIFFICULTY     = uint64(200012262029662)
+	MIN_DIFFICULTY_AT  = uint64(306612262029662)
+	DIFF_BUILD_GENESIS = uint64(290112262029012)
+	DIFF_BT_A          = uint64(298678954710059)
+	DIFF_BT_X          = uint64(291678954710059)
+	DIFF_AT_A          = uint64(311678954710059)
+	// BT PERIOD
+	BT_A = uint64(1587132412)
+	BT_B = uint64(1590157894)
+	BT_C = uint64(1590283479)
+	BT_D = uint64(1590337524)
+	BT_E = uint64(1591666381)
+	BT_F = uint64(1596864102)
+	BT_G = uint64(1597558249)
+	BT_H = uint64(1591666380)
+	// AT PERIOD
+	AT_A = uint64(1625431234)
+	AT_B = uint64(1640266692)
+	AT_C = uint64(1642981050)
+	AT_D = uint64(1644536250)
+	// WIRELESS TRANSMITION MINIMUM
+	WIREMIN_A = uint64(1647116144)
+	WIREMIN_B = uint64(1647126841)
+	// Special block times (magic numbers in js node)
+	SPECIAL_BLOCKTIME_ONE   = uint64(1587132449)
+	SPECIAL_BLOCKTIME_TWO   = uint64(1590132950)
+	SPECIAL_BLOCKTIME_THREE = uint64(1646773191)
+	SPECIAL_BLOCKTIME_FOUR  = uint64(1647022731)
+	SPECIAL_BLOCKTIME_FIVE  = uint64(1647039583)
+)
+
+var BIG_ZERO = new(big.Int).SetInt64(0)
+var BIG_ONE = new(big.Int).SetInt64(1)
+var BIG_TWO = new(big.Int).SetInt64(2)
+var BIG_THREE = new(big.Int).SetInt64(3)
+var BIG_THIRTYSIX = new(big.Int).SetInt64(36)
+var BIG_EIGHTYSIX = new(big.Int).SetInt64(86)
+var BIG_MINUS99 = new(big.Int).SetInt64(-99)
+var BIG_TIMEWINDOW = new(big.Int).SetInt64(8)
+var BIG_STALEWEIGHT = new(big.Int).SetInt64(10)
+var BIG_1000 = new(big.Int).SetInt64(1000)
+var BIG_6000 = new(big.Int).SetInt64(6000)
+var BIG_MAGICNUMBER1 = new(big.Int).SetInt64(1615500)
+var BIG_MAGICNUMBER2 = new(big.Int).SetInt64(161550000)
+var BIG_MAGICNUMBER3 = new(big.Int).SetInt64(1215500)
+var BIG_MAGICNUMBER4 = new(big.Int).SetInt64(1506600)
+var BIG_MAGICNUMBER5 = new(big.Int).SetInt64(16155)
+var BIG_MAGICNUMBER6 = new(big.Int).SetInt64(16055)
+
+// why is all of this in BigInt if they squish it back to a uint64 in js?
+func GetDifficultyPreExp(currentTimestamp, lastBlockTimestamp uint64, lastBlockDiff, minimumDiff *big.Int, nNewBlocks int64, newestHeaderInBlock *p2p_pb.BlockchainHeader) *big.Int {
+	result := new(big.Int)
+
+	actualMinDiff := new(big.Int).SetUint64(MIN_DIFFICULTY)
+	if lastBlockTimestamp > WIREMIN_A {
+		actualMinDiff.SetUint64(MIN_DIFFICULTY_AT)
+	}
+	if minimumDiff.Cmp(actualMinDiff) == 1 {
+		actualMinDiff.Set(minimumDiff)
+	}
+	indexedHeaderTime := new(big.Int).SetUint64(newestHeaderInBlock.GetTimestamp())
+	indexedHeaderTime.Div(indexedHeaderTime, BIG_1000)
+	bigCurrentTime := new(big.Int).SetUint64(currentTimestamp)
+	bigLastTime := new(big.Int).SetUint64(lastBlockTimestamp)
+	bigNNewBlocks := new(big.Int).SetInt64(nNewBlocks)
+	localLastDiff := new(big.Int).Set(lastBlockDiff)
+
+	if indexedHeaderTime.Cmp(bigLastTime) == -1 {
+		indexedHeaderTime.Set(bigLastTime)
+	}
+
+	timeBound := new(big.Int).Set(indexedHeaderTime)
+	timeBound.Add(timeBound, new(big.Int).Mul(BIG_TWO, BIG_TIMEWINDOW))
+
+	elapsedTime := new(big.Int).Sub(bigCurrentTime, bigLastTime)
+
+	if false && elapsedTime.Cmp(BIG_6000) == 1 {
+		elapsedTime.Set(BIG_THREE)
+		localLastDiff.SetUint64(DIFF_BUILD_GENESIS)
+	}
+
+	if lastBlockTimestamp == BT_A || lastBlockTimestamp == SPECIAL_BLOCKTIME_ONE {
+		return result.SetUint64(DIFF_BT_A)
+	}
+	if lastBlockTimestamp == BT_B || lastBlockTimestamp == SPECIAL_BLOCKTIME_TWO {
+		return result.SetUint64(DIFF_BT_X)
+	}
+	if lastBlockTimestamp == BT_C {
+		return result.SetUint64(DIFF_BT_X)
+	}
+	if lastBlockTimestamp == BT_D {
+		return result.SetUint64(DIFF_BT_X)
+	}
+	if lastBlockTimestamp == BT_E {
+		return result.SetUint64(DIFF_BT_X)
+	}
+	if lastBlockTimestamp == BT_F {
+		return result.SetUint64(DIFF_BT_X)
+	}
+	if lastBlockTimestamp == BT_G {
+		return result.SetUint64(DIFF_BT_X)
+	}
+	if lastBlockTimestamp == AT_A {
+		return result.SetUint64(DIFF_AT_A)
+	}
+
+	staleCost := new(big.Int).Div(new(big.Int).Sub(bigCurrentTime, bigLastTime), BIG_TIMEWINDOW)
+
+	if staleCost.Cmp(BIG_ZERO) == 1 && lastBlockTimestamp <= BT_H {
+		elapsedTime.Sub(elapsedTime, staleCost)
+	}
+
+	// someone didn't know how to use ||
+	if lastBlockTimestamp > AT_B && elapsedTime.Cmp(BIG_THIRTYSIX) == 1 && bigNNewBlocks.Cmp(BIG_ONE) == 1 {
+		if (lastBlockTimestamp > AT_D && elapsedTime.Cmp(BIG_EIGHTYSIX) == 1 && bigNNewBlocks.Cmp(BIG_ONE) == 1) ||
+			(lastBlockTimestamp < AT_C) {
+			elapsedTime.Mul(elapsedTime, bigNNewBlocks)
+		}
+	}
+
+	w := new(big.Int).Set(BIG_ZERO)
+	elapsedTimeBonus := new(big.Int).Add(elapsedTime, new(big.Int).Add(new(big.Int).Sub(elapsedTime, BIG_STALEWEIGHT), bigNNewBlocks))
+
+	if lastBlockTimestamp >= SPECIAL_BLOCKTIME_THREE && elapsedTime.Cmp(BIG_EIGHTYSIX) == 1 {
+		w.Set(elapsedTimeBonus) // original elapsed time bonus
+		elapsedTimeBonus.Mul(elapsedTime, bigNNewBlocks)
+	}
+
+	elapsedTime.Set(elapsedTimeBonus)
+
+	x := new(big.Int).Sub(BIG_ONE, new(big.Int).Div(elapsedTime, BIG_TIMEWINDOW))
+	y := new(big.Int)
+	n := new(big.Int)
+	z := new(big.Int).SetInt64(0)
+	m := new(big.Int).SetInt64(0)
+
+	if x.Cmp(BIG_MINUS99) == -1 {
+		z.Set(x)
+		if lastBlockTimestamp < 1647022731 {
+			x.Set(BIG_MINUS99)
+		}
+		if lastBlockTimestamp > WIREMIN_A {
+			x.Set(BIG_MINUS99)
+		}
+	}
+
+	if lastBlockTimestamp > AT_D {
+
+		if x.Cmp(BIG_ZERO) == -1 {
+			if lastBlockTimestamp >= WIREMIN_A {
+				n.Sub(BIG_MAGICNUMBER1, elapsedTimeBonus) // BigInt(1615500) - elapsedTimeBonus; // <-- AT
+			} else if lastBlockTimestamp >= SPECIAL_BLOCKTIME_FOUR {
+				if lastBlockTimestamp >= SPECIAL_BLOCKTIME_FIVE {
+					n.Sub(BIG_MAGICNUMBER2, elapsedTimeBonus) // BigInt(161550000) - elapsedTimeBonus; // <-- AT
+				} else {
+					n.Sub(BIG_MAGICNUMBER1, elapsedTimeBonus) //BigInt(1615500) - elapsedTimeBonus; // <-- AT
+				}
+				if n.Cmp(BIG_ZERO) == -1 {
+					n.Set(BIG_ONE) // BigInt(1);
+				}
+			} else {
+				n.Add(BIG_MAGICNUMBER1, elapsedTimeBonus) // BigInt(1615500) + elapsedTimeBonus; // <-- AT2
+			}
+		} else {
+			if lastBlockTimestamp >= WIREMIN_A {
+				n.Add(BIG_MAGICNUMBER3, elapsedTimeBonus) // = BigInt(1215500) - elapsedTimeBonus; // <-- AT
+			} else if lastBlockTimestamp >= SPECIAL_BLOCKTIME_FIVE {
+				n.Sub(BIG_MAGICNUMBER2, elapsedTimeBonus) //BigInt(161550000) - elapsedTimeBonus; // <-- AT
+			} else {
+				n.Sub(BIG_MAGICNUMBER4, elapsedTimeBonus) // BigInt(1506600) + elapsedTimeBonus; // <-- AT2
+			}
+		}
+	} else {
+		// y = bigPreviousDifficulty -> OVERLINE: 10062600 // AT: 1615520 // BT: ((32 * 16) / 2PI ) * 10 = 815 chain count + hidden chain = 508
+		if x.Cmp(BIG_ZERO) == -1 {
+			// n = BigInt(1615520) + elapsedTimeBonus // <-- BT
+			n.Add(BIG_MAGICNUMBER5, elapsedTimeBonus) //  = BigInt(16155) + elapsedTimeBonus; // <-- AT
+		} else {
+			// n = BigInt(1506600) + elapsedTimeBonus <-- BT
+			n.Add(BIG_MAGICNUMBER6, elapsedTimeBonus) // BigInt(15066) + elapsedTimeBonus; // <-- AT
+		}
+	}
+
+	y.Div(localLastDiff, bigNNewBlocks)
+	// x = x * y
+	x.Mul(x, y)
+	m.Set(x)
+	if lastBlockTimestamp < SPECIAL_BLOCKTIME_FOUR {
+		x.Add(new(big.Int).Add(x, localLastDiff), elapsedTimeBonus)
+	} else {
+		x.Add(x, localLastDiff)
+	}
+
+	// x < ensure follows wireless minimum
+	// prevent web3 routers from competing with GPU miners
+	if x.Cmp(actualMinDiff) == -1 && lastBlockTimestamp > WIREMIN_B {
+		return result.SetUint64(MIN_DIFFICULTY_AT)
+	}
+
+	if x.Cmp(new(big.Int).SetUint64(MIN_DIFFICULTY)) == -1 {
+		return result.SetUint64(MIN_DIFFICULTY)
+	}
+
+	// x < minimalDifficulty
+	if x.Cmp(actualMinDiff) == -1 {
+		return actualMinDiff
+	}
+
+	return result.Set(x)
+}

--- a/src/olhash/difficulty.go
+++ b/src/olhash/difficulty.go
@@ -57,6 +57,7 @@ var BIG_MAGICNUMBER3 = new(big.Int).SetInt64(1215500)
 var BIG_MAGICNUMBER4 = new(big.Int).SetInt64(1506600)
 var BIG_MAGICNUMBER5 = new(big.Int).SetInt64(16155)
 var BIG_MAGICNUMBER6 = new(big.Int).SetInt64(16055)
+var BIG_DECAYCONSTANT = new(big.Int).SetInt64(66000000)
 
 // why is all of this in BigInt if they squish it back to a uint64 in js?
 func GetDifficultyPreExp(currentTimestamp, lastBlockTimestamp uint64, lastBlockDiff, minimumDiff *big.Int, nNewBlocks int64, newestHeaderInBlock *p2p_pb.BlockchainHeader) *big.Int {
@@ -218,4 +219,19 @@ func GetDifficultyPreExp(currentTimestamp, lastBlockTimestamp uint64, lastBlockD
 	}
 
 	return result.Set(x)
+}
+
+func GetExpFactorDiff(calcDiff *big.Int, lastBlockHeight uint64) *big.Int {
+	result := new(big.Int).Set(calcDiff)
+	periodCount := new(big.Int).SetUint64(lastBlockHeight)
+	periodCount.Add(periodCount, BIG_ONE)
+	periodCount.Div(periodCount, BIG_DECAYCONSTANT)
+
+	if periodCount.Cmp(BIG_TWO) == 1 {
+		y := new(big.Int).Sub(periodCount, BIG_TWO)
+		y.Exp(y, BIG_TWO, nil)
+		result.Add(result, y)
+	}
+
+	return result
 }

--- a/src/validation/block_validation.go
+++ b/src/validation/block_validation.go
@@ -175,6 +175,11 @@ func IsFieldLengthBounded(block *p2p_pb.BcBlock) bool {
 }
 
 func IsMerkleRootCorrectlyCalculated(block *p2p_pb.BcBlock) bool {
+	if block.GetHeight() == uint64(6947037) || block.GetHeight() == uint64(6947078) || block.GetHeight() == uint64(6947082) {
+		zap.S().Warnf("Skipping block: %v", block.GetHeight())
+		return true
+	}
+
 	expectedMerkle := block.GetMerkleRoot()
 
 	toHash := []string{}
@@ -225,6 +230,14 @@ func IsDistanceCorrectlyCalculated(block *p2p_pb.BcBlock) bool {
 		return false
 	}
 	diff := new(big.Int).Sub(reCalcDistanceBN, distance)
+	if diff.Uint64() != 0 {
+		zap.S().Warnf("Distance calc'd with: %v %v %v %v %v", work, block.GetMiner(), block.GetMerkleRoot(), block.GetNonce(), block.GetTimestamp())
+		zap.S().Warnf("Block (%v) %v %v != %v", block.GetHeight(), block.GetHash(), distance.String(), reCalcDistanceBN.String())
+		if block.GetHeight() == uint64(6947037) || block.GetHeight() == uint64(6947078) || block.GetHeight() == uint64(6947082) {
+			return true
+		}
+	}
+
 	//diff.Abs(diff)
 	return diff.Uint64() == 0
 }

--- a/src/validation/chain_validation.go
+++ b/src/validation/chain_validation.go
@@ -128,6 +128,14 @@ func wavContiguityProblems(low, high *p2p_pb.BcBlock) bool {
 }
 
 func OrderedBlockPairIsValid(low, high *p2p_pb.BcBlock) bool {
+	return orderedBlockPairIsValid(low, high, false)
+}
+
+func OrderedBlockPairIsValidStrict(low, high *p2p_pb.BcBlock) bool {
+	return orderedBlockPairIsValid(low, high, true)
+}
+
+func orderedBlockPairIsValid(low, high *p2p_pb.BcBlock, isStrict bool) bool {
 	const nitPickedValidationHeight = uint64(6850000)
 	if (high.GetHeight()-1 != low.GetHeight()) || (high.GetPreviousHash() != low.GetHash()) {
 		return false
@@ -135,41 +143,42 @@ func OrderedBlockPairIsValid(low, high *p2p_pb.BcBlock) bool {
 	if low.GetHeight() != 1 { // do not validate headers if comparing to genesis block
 		if !globalContiguityProblems(low, high) {
 			if !btcContiguityProblems(low, high) && !HeaderRangeIsContiguous(low.GetBlockchainHeaders().GetBtc(), high.GetBlockchainHeaders().GetBtc()) {
-				if low.GetHeight() >= nitPickedValidationHeight {
+				if low.GetHeight() >= nitPickedValidationHeight && !isStrict {
 					zap.S().Warnf("Problem in BTC contiguity spanning blocks %v %v -> %v %v", low.GetHeight(), common.BriefHash(low.GetHash()), high.GetHeight(), common.BriefHash(high.GetHash()))
 				} else {
 					return false
 				}
 			}
 			if !ethContiguityProblems(low, high) && !HeaderRangeIsContiguous(low.GetBlockchainHeaders().GetEth(), high.GetBlockchainHeaders().GetEth()) {
-				if low.GetHeight() >= nitPickedValidationHeight {
+				if low.GetHeight() >= nitPickedValidationHeight && !isStrict {
 					zap.S().Warnf("Problem in ETH contiguity spanning blocks %v %v -> %v %v", low.GetHeight(), common.BriefHash(low.GetHash()), high.GetHeight(), common.BriefHash(high.GetHash()))
 				} else {
 					return false
 				}
 			}
 			if !lskContiguityProblems(low, high) && !HeaderRangeIsContiguous(low.GetBlockchainHeaders().GetLsk(), high.GetBlockchainHeaders().GetLsk()) {
-				if low.GetHeight() >= nitPickedValidationHeight {
+				if low.GetHeight() >= nitPickedValidationHeight && !isStrict {
 					zap.S().Warnf("Problem in LSK contiguity spanning blocks %v %v -> %v %v", low.GetHeight(), common.BriefHash(low.GetHash()), high.GetHeight(), common.BriefHash(high.GetHash()))
 				} else {
 					return false
 				}
 			}
 			if !neoContiguityProblems(low, high) && !HeaderRangeIsContiguous(low.GetBlockchainHeaders().GetNeo(), high.GetBlockchainHeaders().GetNeo()) {
-				if low.GetHeight() >= nitPickedValidationHeight {
+				if low.GetHeight() >= nitPickedValidationHeight && !isStrict {
 					zap.S().Warnf("Problem in NEO contiguity spanning blocks %v %v -> %v %v", low.GetHeight(), common.BriefHash(low.GetHash()), high.GetHeight(), common.BriefHash(high.GetHash()))
 				} else {
 					return false
 				}
 			}
 			if !wavContiguityProblems(low, high) && !HeaderRangeIsContiguous(low.GetBlockchainHeaders().GetWav(), high.GetBlockchainHeaders().GetWav()) {
-				if low.GetHeight() >= nitPickedValidationHeight {
+				if low.GetHeight() >= nitPickedValidationHeight && !isStrict {
 					zap.S().Warnf("Problem in WAV contiguity spanning blocks %v %v -> %v %v", low.GetHeight(), common.BriefHash(low.GetHash()), high.GetHeight(), common.BriefHash(high.GetHash()))
 				} else {
 					return false
 				}
 			}
 		}
+
 	}
 	return true
 }

--- a/src/validation/chain_validation.go
+++ b/src/validation/chain_validation.go
@@ -229,3 +229,40 @@ func HeaderRangeIsContiguous(low, high []*p2p_pb.BlockchainHeader) bool {
 	}
 	return (isChained(low, high))
 }
+
+func validateDifficultyProgression(low, high *p2p_pb.BcBlock) bool {
+	if low.GetHeight() < 4 && high.GetHeight() < 4 {
+		return true
+	}
+
+	totalHeightChange := GetNewIndexedHeightChange(low, high)
+
+	if totalHeightChange < 0 {
+		return false
+	}
+
+	return true
+}
+
+func headerHeightDiff(low, high []*p2p_pb.BlockchainHeader) int64 {
+	return int64(high[len(high)-1].GetHeight()) - int64(low[len(low)-1].GetHeight())
+}
+
+func GetNewIndexedHeightChange(low, high *p2p_pb.BcBlock) int64 {
+	nNew := int64(0)
+
+	lowHeaders := low.GetBlockchainHeaders()
+	highHeaders := high.GetBlockchainHeaders()
+
+	nNew += headerHeightDiff(lowHeaders.GetBtc(), highHeaders.GetBtc())
+	nNew += headerHeightDiff(lowHeaders.GetEth(), highHeaders.GetEth())
+	nNew += headerHeightDiff(lowHeaders.GetLsk(), highHeaders.GetLsk())
+	nNew += headerHeightDiff(lowHeaders.GetNeo(), highHeaders.GetNeo())
+	nNew += headerHeightDiff(lowHeaders.GetWav(), highHeaders.GetWav())
+
+	return nNew
+}
+
+func validateDistanceProgression(low, high []*p2p_pb.BcBlock) bool {
+	return true
+}


### PR DESCRIPTION
starting from #17's list of tasks:
- [x] validate chain structure in addition to individual blocks (see n.b.)
- [ ] local database validation reports non-contiguous parts of local chain and gets missing blocks (this is the wrong PR for this)
- [ ] sync from beginning (initial block download) detects incomplete block requests and resubmits (this is the wrong PR for this)
- [x] implement blockchain logic
- [x] implement smooth transition from initial block download to standard block ingestion

n.b.: All recorded problems with child-chain contiguity are marked and described in `chain_validation.go` after block 6850000 errors in child-chain contiguity are emitted as warnings to reduce maintenance burden. This implementation of the node will ensure that child-chain contiguity is always enforced (this is compatible with the current chain rules but not required). 
The reason being that in order for pruned or "light" nodes to work and for individual blocks to be useful outside a full copy of the chain they must obey block-pairwise contiguity of child-chains. Otherwise it is impossible to know how deep one must dig in the chain to ensure state.




