### PR TITLE
Ensure we get the same results for fiddly floating point math on amd64 and arm64

### DIFF
--- a/src/database/db.go
+++ b/src/database/db.go
@@ -510,8 +510,6 @@ func (odb *OverlineDB) FullLocalValidation() {
 					errstr := fmt.Sprintf("%v -> %v does not form a valid chain", prevBlock.GetHash(), block.GetHash())
 					zap.S().Debug(errstr)
 					return errors.New(errstr)
-				} else {
-					zap.S().Debugf("%v -> %v forms a valid chain", prevBlock.GetHash(), block.GetHash())
 				}
 			} else {
 				zap.S().Debugf("Invalid block %v has height %v, expecting %v", common.BriefHash(block.GetHash()), block.GetHeight(), height)

--- a/src/validation/block_validation.go
+++ b/src/validation/block_validation.go
@@ -217,8 +217,6 @@ func IsDistanceAboveDifficulty(block *p2p_pb.BcBlock) bool {
 func IsDistanceCorrectlyCalculated(block *p2p_pb.BcBlock) bool {
 	// we have to use a tolerance here because of javascript's weird floating point
 	// implementation
-	const tolValue = uint64(10)
-	tol := new(big.Int).SetUint64(tolValue)
 	work := prepareWork(block)
 	reCalcDistance := olhash.EvalString(work, block.GetMiner(), block.GetMerkleRoot(), block.GetNonce(), block.GetTimestamp())
 	reCalcDistanceBN := new(big.Int).SetUint64(reCalcDistance)
@@ -227,11 +225,8 @@ func IsDistanceCorrectlyCalculated(block *p2p_pb.BcBlock) bool {
 		return false
 	}
 	diff := new(big.Int).Sub(reCalcDistanceBN, distance)
-	diff.Abs(diff)
-	if diff.Uint64() != 0 {
-		zap.S().Debugf("Distances different but within tolerance: %v != %v", reCalcDistanceBN, distance)
-	}
-	return diff.Cmp(tol) <= 0
+	//diff.Abs(diff)
+	return diff.Uint64() == 0
 }
 
 func IsValidBlockTime(block *p2p_pb.BcBlock) bool {


### PR DESCRIPTION
arm64 has some fused multiple accumulate operators that are not available in amd64.
Force the code to not use them and make the block distance checks more strict.