### PR TITLE
Remove arm from lisk cd

### DIFF
--- a/.github/workflows/cd-lisk.yml
+++ b/.github/workflows/cd-lisk.yml
@@ -30,5 +30,5 @@ jobs:
           BUILD=$(git rev-parse --short HEAD)
           VERSION=${TAG}-g${BUILD}
 
-          docker/build-lisk.sh linux/amd64,linux/arm/v7,linux/arm64 ${{ secrets.DOCKERHUB_ACCOUNT }} ${VERSION} --push
-          docker/build-lisk.sh linux/amd64,linux/arm/v7,linux/arm64 ${{ secrets.DOCKERHUB_ACCOUNT }} latest --push
+          docker/build-lisk.sh linux/amd64 ${{ secrets.DOCKERHUB_ACCOUNT }} ${VERSION} --push
+          docker/build-lisk.sh linux/amd64 ${{ secrets.DOCKERHUB_ACCOUNT }} latest --push


### PR DESCRIPTION
rocksdb doesn't compile on arm for some reason.